### PR TITLE
integrate swaggerUI to view apis

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -24,3 +24,6 @@ curl --location --request GET 'http://localhost:8080/users/'
 ```bash
 docker-compose down
 ```
+
+### View swagger UI of apis: 
+localhost:8080/swagger-ui.html

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -42,6 +42,12 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-ui</artifactId>
+			<version>1.6.11</version>
+		 </dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/16641040/190246490-f3d19b78-2d24-4981-b205-7b143937bf12.png">
view swagger UI of current apis using: localhost:8080/swagger-ui.html
