### PR TITLE
Make all endpoints protected

### DIFF
--- a/api_server/src/main/java/io/zetch/app/security/SecurityConfig.java
+++ b/api_server/src/main/java/io/zetch/app/security/SecurityConfig.java
@@ -6,7 +6,6 @@ package io.zetch.app.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -26,17 +25,7 @@ public class SecurityConfig {
     */
     http.cors().and().csrf().disable(); // NOSONAR not used in secure contexts
 
-    http.authorizeRequests(
-            authReqCustomizer ->
-                authReqCustomizer
-                    .antMatchers("/private")
-                    .authenticated()
-                    .antMatchers(HttpMethod.PUT, "/users/")
-                    .authenticated()
-                    .antMatchers(HttpMethod.DELETE, "/users/")
-                    .authenticated()
-                    .anyRequest()
-                    .permitAll())
+    http.authorizeRequests(authReqCustomizer -> authReqCustomizer.anyRequest().authenticated())
         .oauth2ResourceServer()
         .jwt();
 

--- a/api_server/src/main/java/io/zetch/app/web/HelloController.java
+++ b/api_server/src/main/java/io/zetch/app/web/HelloController.java
@@ -7,20 +7,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class HelloController {
 
-  @GetMapping("/")
-  public String index1() {
-    return "Greetings from Spring Boot!";
-  }
-
-  @GetMapping("/public")
-  public String index2() {
-    return "Greetings from Spring Boot! This is public.";
-  }
-
   /** An example of a route getting a username from the token */
   @GetMapping("/private")
-  public String index3(JwtAuthenticationToken principal) {
-    String username = principal.getToken().getClaimAsString("username");
+  public String index3(JwtAuthenticationToken token) {
+    String username = token.getToken().getClaimAsString("username");
 
     return String.format("Greetings from Spring Boot. You are %s!", username);
   }

--- a/api_server/src/main/java/io/zetch/app/web/RestaurantController.java
+++ b/api_server/src/main/java/io/zetch/app/web/RestaurantController.java
@@ -1,6 +1,7 @@
 package io.zetch.app.web;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.zetch.app.domain.restaurant.RestaurantDto;
 import io.zetch.app.domain.restaurant.RestaurantEntity;
@@ -29,6 +30,7 @@ public class RestaurantController {
    */
   @GetMapping(path = "/")
   @Operation(summary = "Retrieve all restaurants")
+  @SecurityRequirement(name = "OAuth2")
   @ResponseBody
   Iterable<RestaurantDto> getAllRestaurants() {
     return restaurantService.getAll().stream()
@@ -42,6 +44,7 @@ public class RestaurantController {
    */
   @GetMapping("/{name}")
   @Operation(summary = "Retrieve a single restaurant")
+  @SecurityRequirement(name = "OAuth2")
   RestaurantDto getOneRestaurant(@PathVariable String name) {
     return restaurantService.getOne(name).toDto();
   }
@@ -52,6 +55,7 @@ public class RestaurantController {
    */
   @PutMapping("/{name}")
   @Operation(summary = "Modify a single restaurant")
+  @SecurityRequirement(name = "OAuth2")
   RestaurantDto updateRestaurant(
       @RequestBody RestaurantDto newRestaurantDto, @PathVariable String name) {
     return restaurantService
@@ -69,6 +73,7 @@ public class RestaurantController {
    */
   @PutMapping("/{name}/{owner}")
   @Operation(summary = "Assign owner to a restaurant")
+  @SecurityRequirement(name = "OAuth2")
   RestaurantDto assignRestaurantOwner(@PathVariable String name, @PathVariable String owner) {
     return restaurantService.assignOwner(name, owner).toDto();
   }
@@ -79,6 +84,7 @@ public class RestaurantController {
    */
   @PostMapping(path = "/")
   @Operation(summary = "Create a new restaurant")
+  @SecurityRequirement(name = "OAuth2")
   @ResponseBody
   RestaurantDto addNewRestaurant(@RequestBody @Validated RestaurantDto restaurantDto) {
     return restaurantService

--- a/api_server/src/main/java/io/zetch/app/web/RestaurantController.java
+++ b/api_server/src/main/java/io/zetch/app/web/RestaurantController.java
@@ -10,6 +10,7 @@ import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -32,7 +33,7 @@ public class RestaurantController {
   @Operation(summary = "Retrieve all restaurants")
   @SecurityRequirement(name = "OAuth2")
   @ResponseBody
-  Iterable<RestaurantDto> getAllRestaurants() {
+  Iterable<RestaurantDto> getAllRestaurants(JwtAuthenticationToken token) {
     return restaurantService.getAll().stream()
         .map(RestaurantEntity::toDto)
         .collect(Collectors.toList());
@@ -45,7 +46,7 @@ public class RestaurantController {
   @GetMapping("/{name}")
   @Operation(summary = "Retrieve a single restaurant")
   @SecurityRequirement(name = "OAuth2")
-  RestaurantDto getOneRestaurant(@PathVariable String name) {
+  RestaurantDto getOneRestaurant(@PathVariable String name, JwtAuthenticationToken token) {
     return restaurantService.getOne(name).toDto();
   }
 
@@ -57,7 +58,9 @@ public class RestaurantController {
   @Operation(summary = "Modify a single restaurant")
   @SecurityRequirement(name = "OAuth2")
   RestaurantDto updateRestaurant(
-      @RequestBody RestaurantDto newRestaurantDto, @PathVariable String name) {
+      @RequestBody RestaurantDto newRestaurantDto,
+      @PathVariable String name,
+      JwtAuthenticationToken token) {
     return restaurantService
         .update(
             name,
@@ -74,7 +77,8 @@ public class RestaurantController {
   @PutMapping("/{name}/{owner}")
   @Operation(summary = "Assign owner to a restaurant")
   @SecurityRequirement(name = "OAuth2")
-  RestaurantDto assignRestaurantOwner(@PathVariable String name, @PathVariable String owner) {
+  RestaurantDto assignRestaurantOwner(
+      @PathVariable String name, @PathVariable String owner, JwtAuthenticationToken token) {
     return restaurantService.assignOwner(name, owner).toDto();
   }
 
@@ -86,7 +90,8 @@ public class RestaurantController {
   @Operation(summary = "Create a new restaurant")
   @SecurityRequirement(name = "OAuth2")
   @ResponseBody
-  RestaurantDto addNewRestaurant(@RequestBody @Validated RestaurantDto restaurantDto) {
+  RestaurantDto addNewRestaurant(
+      @RequestBody @Validated RestaurantDto restaurantDto, JwtAuthenticationToken token) {
     return restaurantService
         .createNew(restaurantDto.getName(), restaurantDto.getCuisine(), restaurantDto.getAddress())
         .toDto();

--- a/api_server/src/main/java/io/zetch/app/web/UserController.java
+++ b/api_server/src/main/java/io/zetch/app/web/UserController.java
@@ -47,6 +47,7 @@ public class UserController {
 
   @PostMapping(path = "/")
   @Operation(summary = "Create a new user")
+  @SecurityRequirement(name = "OAuth2")
   @ResponseBody
   UserDto addNewUser(@RequestBody UserDto newUserDto) {
     return userService
@@ -60,6 +61,7 @@ public class UserController {
 
   @GetMapping("/{username}")
   @Operation(summary = "Retrieve a single user")
+  @SecurityRequirement(name = "OAuth2")
   UserDto getOneUser(@PathVariable String username) {
     return userService.getOne(username).toDto();
   }

--- a/api_server/src/main/java/io/zetch/app/web/UserController.java
+++ b/api_server/src/main/java/io/zetch/app/web/UserController.java
@@ -49,7 +49,7 @@ public class UserController {
   @Operation(summary = "Create a new user")
   @SecurityRequirement(name = "OAuth2")
   @ResponseBody
-  UserDto addNewUser(@RequestBody UserDto newUserDto) {
+  UserDto addNewUser(@RequestBody UserDto newUserDto, JwtAuthenticationToken token) {
     return userService
         .createNew(
             newUserDto.getUsername(),
@@ -62,7 +62,7 @@ public class UserController {
   @GetMapping("/{username}")
   @Operation(summary = "Retrieve a single user")
   @SecurityRequirement(name = "OAuth2")
-  UserDto getOneUser(@PathVariable String username) {
+  UserDto getOneUser(@PathVariable String username, JwtAuthenticationToken token) {
     return userService.getOne(username).toDto();
   }
 

--- a/api_server/src/test/java/io/zetch/app/web/HelloControllerTest.java
+++ b/api_server/src/test/java/io/zetch/app/web/HelloControllerTest.java
@@ -33,14 +33,6 @@ class HelloControllerTest {
     mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
   }
 
-  @Test
-  void index1() throws Exception {
-    mockMvc
-        .perform(get("/"))
-        .andExpect(status().isOk())
-        .andExpect(content().string("Greetings from Spring Boot!"));
-  }
-
   /** An example of how a private route can be tested */
   @Test
   @WithMockJwtAuth(

--- a/api_server/src/test/java/io/zetch/app/web/RestaurantControllerTest.java
+++ b/api_server/src/test/java/io/zetch/app/web/RestaurantControllerTest.java
@@ -11,6 +11,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.c4_soft.springaddons.security.oauth2.test.annotations.Claims;
+import com.c4_soft.springaddons.security.oauth2.test.annotations.OpenIdClaims;
+import com.c4_soft.springaddons.security.oauth2.test.annotations.StringClaim;
+import com.c4_soft.springaddons.security.oauth2.test.annotations.WithMockJwtAuth;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.zetch.app.domain.restaurant.RestaurantDto;
 import io.zetch.app.domain.restaurant.RestaurantEntity;
@@ -35,6 +39,11 @@ import org.springframework.web.context.WebApplicationContext;
 @SpringBootTest
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
+@WithMockJwtAuth(
+    claims =
+        @OpenIdClaims(
+            otherClaims =
+                @Claims(stringClaims = @StringClaim(name = "username", value = "some_user"))))
 public class RestaurantControllerTest {
 
   private static final String RESTAURANT_ENDPOINT = "/restaurants/";

--- a/api_server/src/test/java/io/zetch/app/web/UserControllerTest.java
+++ b/api_server/src/test/java/io/zetch/app/web/UserControllerTest.java
@@ -43,6 +43,11 @@ import org.springframework.web.context.WebApplicationContext;
 @SpringBootTest
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
+@WithMockJwtAuth(
+    claims =
+        @OpenIdClaims(
+            otherClaims =
+                @Claims(stringClaims = @StringClaim(name = "username", value = "some_user"))))
 class UserControllerTest {
 
   private static final String USERS_ENDPOINT = "/users/";
@@ -227,25 +232,6 @@ class UserControllerTest {
   }
 
   @Test
-  void updateUserAttrs_NoAuth() throws Exception {
-    UserEntity updated =
-        UserEntity.builder()
-            .username(USERNAME_1)
-            .displayName("Bob New")
-            .email("bob_new@me.com")
-            .affiliation(Affiliation.FACULTY)
-            .build();
-
-    MockHttpServletRequestBuilder mockRequest =
-        put(USERS_ENDPOINT + USERNAME_1)
-            .contentType(MediaType.APPLICATION_JSON)
-            .accept(MediaType.APPLICATION_JSON)
-            .content(mapper.writeValueAsString(updated.toDto()));
-
-    mockMvc.perform(mockRequest).andExpect(status().isUnauthorized());
-  }
-
-  @Test
   @WithMockJwtAuth(
       claims =
           @OpenIdClaims(
@@ -341,18 +327,6 @@ class UserControllerTest {
             .accept(MediaType.APPLICATION_JSON);
 
     mockMvc.perform(mockRequest).andExpect(status().isForbidden());
-  }
-
-  @Test
-  void deleteUser_NoAuth() throws Exception {
-    when(userServiceMock.delete(u1.getUsername())).thenReturn(u1);
-
-    MockHttpServletRequestBuilder mockRequest =
-        delete(USERS_ENDPOINT + USERNAME_1)
-            .contentType(MediaType.APPLICATION_JSON)
-            .accept(MediaType.APPLICATION_JSON);
-
-    mockMvc.perform(mockRequest).andExpect(status().isUnauthorized());
   }
 
   @Test


### PR DESCRIPTION
1. All endpoints are now behind auth:
https://github.com/astrohsy/ZETCH/blob/ea30c1ca64cc01831abc7a07d1a2b1ff698804c5/api_server/src/main/java/io/zetch/app/security/SecurityConfig.java#L28

2. Every controller method has `JwtAuthenticationToken` as one of the arguments. Currently not actually used in some methods, but will be in the future for logging.

3. When testing controllers, you can annotate the whole test class with `@WithMockJwtAuth` so that every test method uses some mock authenticated user:

https://github.com/astrohsy/ZETCH/blob/ea30c1ca64cc01831abc7a07d1a2b1ff698804c5/api_server/src/test/java/io/zetch/app/web/UserControllerTest.java#L46-L51

But when testing endpoints that have auth-based logic, then you can annotate specific methods and override the mock user: 

https://github.com/astrohsy/ZETCH/blob/ea30c1ca64cc01831abc7a07d1a2b1ff698804c5/api_server/src/test/java/io/zetch/app/web/UserControllerTest.java#L86-L92