### PR TITLE
ci: add Maven profiles to separate tests

### DIFF
--- a/api_server/README.md
+++ b/api_server/README.md
@@ -1,7 +1,11 @@
 # Zetch API Server
+
 ## How to build, run, and test
+
 ### 1. Build and run entire development environment
-**Important:** See a ZETCH team member for a `.env` file specifying secret values, place the file in `src/main/resources/`.
+
+**Important:** See a ZETCH team member for a `.env` file specifying secret values, place the file
+in `src/main/resources/`.
 
 ```
 docker-compose build && docker-compose up -d
@@ -10,34 +14,55 @@ docker-compose build && docker-compose up -d
 Note: the docker-compose build section is only necessary if you have made code changes
 
 ### 2. Stop environment
+
 ```
 docker-compose down --remove-orphans
 ```
 
 ### 3. View running logs
+
 ```
 docker-compose logs -f
 ```
 
 ### 4. Run a specific service
+
 Database: `docker-compose up db -d`
 
 API: `docker-compose up api -d`
 
 ### 5. Testing
-JUnit tests:
+
+Run all tests:
+
 ```shell
 ZETCH/api_server$ ./mvnw test
 ```
+
 Jacoco coverage is generated in `api_server/target/site/jacoco/index.html`.
 
-Integration tests are run in postman: 
+Run unit tests only:
+
+```shell
+ZETCH/api_server$ ./mvnw test -Punit-tests
+```
+
+Run integration tests only:
+
+```shell
+ZETCH/api_server$ ./mvnw test -Pintegration-tests
+```
+
+System tests are run in postman:
+
 ```shell
 newman run https://api.getpostman.com/collections/23680701-9829f32b-1694-4065-b6b9-93cbc808c454?apikey={{postman-api-key}}
 ```
+
 **Important:** See a ZETCH team member for postman-api-key.
 
 ## Style checker
+
 ```shell
 ZETCH/api_server$ ./mvnw checkstyle:checkstyle
 ```
@@ -45,6 +70,7 @@ ZETCH/api_server$ ./mvnw checkstyle:checkstyle
 Checkstyle report is in `api_server/reports/checkstyle.html`.
 
 ## Static analysis
+
 ```shell
 ZETCH/api_server$ ./mvnw pmd:pmd
 ```
@@ -58,14 +84,20 @@ https://sonarcloud.io/project/overview?id=astrohsy_ZETCH
 ```
 
 ## API Documentation
+
 ### View Swagger UI
+
 `localhost:8080/swagger-ui/index.html`
 
 ### View deployed Swagger UI
+
 `https://zetch.tech/swagger-ui/index.html`
 
 ### Authentication notes
-All API endpoints are protected by OAuth2 authentication using AWS Cognito. Some endpoints perform additional security checks. See the Swagger documentation for more details (for example, to view client logs a user has to belong to that client).
+
+All API endpoints are protected by OAuth2 authentication using AWS Cognito. Some endpoints perform
+additional security checks. See the Swagger documentation for more details (for example, to view
+client logs a user has to belong to that client).
 
 For testing/demo, the following existing users can login:
 
@@ -76,10 +108,13 @@ For testing/demo, the following existing users can login:
 Every user has the same password -- `123456`.
 
 #### Generating Auth tokens
+
 ##### In Postman
+
 Utilizing [variables](https://learning.postman.com/docs/sending-requests/variables/):
 
 ![postman_auth_config.png](docs/postman_auth_config.png)
 
 ##### In Swagger UI
+
 In Swagger UI, click on Authorize, then enter a client id from `.env`.

--- a/api_server/README.md
+++ b/api_server/README.md
@@ -75,7 +75,7 @@ Checkstyle report is in `api_server/reports/checkstyle.html`.
 ZETCH/api_server$ ./mvnw pmd:pmd
 ```
 
-PMD report is generated in `api_server/target/site/jacoco/index.html`.
+PMD report is generated in `api_server/target/site/pmd.html`.
 
 In addition, we are utilizing SonarCloud:
 

--- a/api_server/pom.xml
+++ b/api_server/pom.xml
@@ -161,6 +161,44 @@
     <token>jwt</token>
   </properties>
 
+  <profiles>
+    <profile>
+      <id>unit-tests</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <excludes>
+                <exclude>**/*IntegrationTest.java</exclude>
+              </excludes>
+              <includes>
+                <include>**/*Test.java</include>
+              </includes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>integration-tests</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>**/*IntegrationTest.java</include>
+              </includes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+  </profiles>
   <version>0.0.1-SNAPSHOT</version>
 
 </project>


### PR DESCRIPTION
Run unit tests only (files ending in `Test`):

```shell
ZETCH/api_server$ ./mvnw test -Punit-tests
```

Run integration tests only (files ending in `IntegrationTest`):

```shell
ZETCH/api_server$ ./mvnw test -Pintegration-tests
```