### PR TITLE
tests: exclude seed classes from Jacoco reports

### DIFF
--- a/api_server/pom.xml
+++ b/api_server/pom.xml
@@ -12,6 +12,11 @@
       </plugin>
       <plugin>
         <artifactId>jacoco-maven-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>io/zetch/app/seed/*</exclude>
+          </excludes>
+        </configuration>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
I don't think we are expected to test the seed classes, and they cause a lot of missed branches in the test coverage report.